### PR TITLE
Enable syntax highlighting for AdBlock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-#Track txt/md files
+# Ignore files that possess a file-extension
+*?.*
+
+# Track text and markdown files
 !*.txt
 !*.md
-
-#Ignore all other types of files
-*.*


### PR DESCRIPTION
See abp-filters/abp-filters-anti-cv#1163. This PR essentially makes the same changes, albeit with a tweak to `.gitignore` to avoid ignoring `.gitattributes`.